### PR TITLE
feat(learning dao): 添加修改收费标准和物业计费报告的实体类- 新增 ModifyChargeRatePage 类，用于修改收费标准页面的数据操作- 新增 PropertyBillingReport 类，用于物业计费报告的数据操作- 两个类均继承自 BaseEntity，并实现了数据存储功能

### DIFF
--- a/PropGuardian.iml
+++ b/PropGuardian.iml
@@ -18,7 +18,7 @@
         <SOURCES />
       </library>
     </orderEntry>
-    <orderEntry type="library" name="hutool-all-5.8.26" level="project" />
-    <orderEntry type="library" name="mysql-connector-java-8.0.30" level="project" />
+    <orderEntry type="library" exported="" name="cn.hutool.all" level="project" />
+    <orderEntry type="library" exported="" name="mysql.connector.java" level="project" />
   </component>
 </module>


### PR DESCRIPTION
- 新增了多个 week 步骤的 Animal、Mouse、Penguin 和 Step1Main 类- 新增了多个 week 步骤的 StudentExtractor 类，用于提取学生信息
- 这些类和程序主要用于学习和演示目的
- 数据操作- 新增 PropertyBillingReport 类，用于物业计费报告的数据操作- 两个类均继承自 BaseEntity，并实现了数据存储功能 
-  @TalexDreamSoul 