### PR TITLE
fix(gui): 修复业主索引条目页面的表读数输入

### DIFF
--- a/PropGuardian.iml
+++ b/PropGuardian.iml
@@ -18,7 +18,7 @@
         <SOURCES />
       </library>
     </orderEntry>
-    <orderEntry type="library" name="hutool-all-5.8.26" level="project" />
-    <orderEntry type="library" name="mysql-connector-java-8.0.30" level="project" />
+    <orderEntry type="library" name="cn.hutool.all" level="project" />
+    <orderEntry type="library" name="mysql.connector.java" level="project" />
   </component>
 </module>

--- a/src/gui/OwnerIndexEntryPage.java
+++ b/src/gui/OwnerIndexEntryPage.java
@@ -180,8 +180,8 @@ public class OwnerIndexEntryPage extends JFrame {
                     Double.parseDouble(waterReading1),
                     Double.parseDouble(electricReading1),
                     Double.parseDouble(gasReading1),
-                    null,
-                    null
+                    -1,
+                    -1
             );
 
             // 添加社区和楼宇信息，确保它们是有效的数字字符串
@@ -200,8 +200,8 @@ public class OwnerIndexEntryPage extends JFrame {
                     Double.parseDouble(waterReading2),
                     Double.parseDouble(electricReading2),
                     Double.parseDouble(gasReading2),
-                    null,
-                    null
+                    -1,
+                    -1
             );
 
             // 添加社区和楼宇信息，确保它们是有效的数字字符串


### PR DESCRIPTION
- 将 null 值替换为 -1，以确保数据类型一致性
- 修复了可能导致类型转换错误的问题
- @TalexDreamSoul @Puffyollmmm 